### PR TITLE
feat: add support for Furtrack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Telegram bot to automatically convert links into embed-friendly ones for Telegra
   > instagram.com ➡️ ddinstagram.com
 - TikTok
   > tiktok.com ➡️ tfxktok.com
+- Furtrack
+  > furtrack.com ➡️ furtrack.owo.lgbt
 - Music (through [Odesli's API](https://odesli.co))
   > open.spotify.com, music.apple.com, music.youtube.com, tidal.com, pandora.com, deezer.com, soundcloud.com, music.amazon.com ➡️ song.link
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -36,6 +36,11 @@ links:
       - https://tiktok.com
     destination: https://tfxktok.com
     enabled: true
+  - name: Furtrack
+    origins:
+      - https://furtrack.com
+    destination: https://furtrack.owo.lgbt
+    enabled: true
 apis:
   - name: Odesli
     enabled: true


### PR DESCRIPTION
`furtrack.owo.lgbt` has been generously provided by t.me/dynamicbark.

Note that it only supports permalinks (`/p/{id}`), which can be copied from a photo's page.