### PR TITLE
feat: Improve furtrack regex

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -23,7 +23,7 @@ links:
     origins:
       - https://furtrack.com/p/
     origins_regex:
-      - ^https:\/\/www\.furtrack\.com\/index\/(\w+:)?\w+(\(\w+\))?\/
+      - ^https:\/\/(www\.)?furtrack\.com\/(\w+\/)?(\w+[:/])?\w+(\(\w+\))?\/
     destination: https://furtrack.owo.lgbt/p/
   - name: Reddit
     origins:

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:alpine
+FROM denoland/deno:alpine-2.1.9
 
 WORKDIR /app
 

--- a/src/main_test.ts
+++ b/src/main_test.ts
@@ -107,13 +107,39 @@ Deno.test("FurTrack-specific constraint", function (): void
 	assert(!Converter.isSupported(NavLink))
 })
 
-Deno.test("FurTrack-specific translation", async function (): Promise<void>
+const furtrackRegExp: RegExp = /^https:\/\/(www\.)?furtrack\.com\/(\w+\/)?(\w+[:/])?\w+(\(\w+\))?\//i
+const FurTrackConverter: SimpleLinkConverter = new SimpleLinkConverter("FurTrack", [new URL("https://furtrack.com/p/")], [furtrackRegExp], new URL("https://furtrack.owo.lgbt/p/"))
+
+Deno.test("FurTrack index translation", async function (): Promise<void>
 {
-	const Converter: SimpleLinkConverter = new SimpleLinkConverter("FurTrack", [new URL("https://furtrack.com/p/")], [/^https:\/\/www\.furtrack\.com\/index\/(\w+:)?\w+(\(\w+\))?\//i], new URL("https://furtrack.owo.lgbt/p/"))
 	const NavLink = new URL("https://www.furtrack.com/index/character:yin_(wolf)/880404")
 	const ConvertedLink = new URL("https://furtrack.owo.lgbt/p/880404")
 
-	assertEquals(await Converter.parseLink(NavLink), ConvertedLink)
+	assertEquals(await FurTrackConverter.parseLink(NavLink), ConvertedLink)
+})
+
+Deno.test("FurTrack user favs page translation", async function (): Promise<void>
+{
+	const NavLink = new URL("https://www.furtrack.com/user/bark/likes/691174")
+	const ConvertedLink = new URL("https://furtrack.owo.lgbt/p/691174")
+
+	assertEquals(await FurTrackConverter.parseLink(NavLink), ConvertedLink)
+})
+
+Deno.test("FurTrack user fursuiting page translation", async function (): Promise<void>
+{
+	const NavLink = new URL("https://www.furtrack.com/user/bark/fursuiting/888628")
+	const ConvertedLink = new URL("https://furtrack.owo.lgbt/p/888628")
+
+	assertEquals(await FurTrackConverter.parseLink(NavLink), ConvertedLink)
+})
+
+Deno.test("FurTrack user photography page translation", async function (): Promise<void>
+{
+	const NavLink = new URL("https://www.furtrack.com/user/bark/photography/753398")
+	const ConvertedLink = new URL("https://furtrack.owo.lgbt/p/753398")
+
+	assertEquals(await FurTrackConverter.parseLink(NavLink), ConvertedLink)
 })
 
 Deno.test("Music-specific test case", async (): Promise<void> =>


### PR DESCRIPTION
Since chatting with dynamicbark (the person behind furtrack.owo.lgbt), I learned there are other link formats that could point toward a picture instead of just `/index/${id}`.
So, I improved the RegEx to support them.