### PR TITLE
Fix pipelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
   # - package-ecosystem: "deno"
   #   directory: "/"
   #   schedule:
-  #     interval: "weekly"
+  #     interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   # - package-ecosystem: "deno"
   #   directory: "/"
   #   schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build container image
+name: Test conversion use-cases
 on:
     pull_request:
         branches:


### PR DESCRIPTION
The use-cases testing pipeline was wrongly named (copy-pasta error). It's now appropriately named.
Dependabot now runs on a monthly schedule instead of weekly. That should help with costs.