### PR TITLE
fix: Add link preview option to prefer large media

### DIFF
--- a/src/actions/main.ts
+++ b/src/actions/main.ts
@@ -400,8 +400,8 @@ export class MainActions implements BotActions
 				const convertedLinks: URL[] = await Converter.parseLink(new URL(link))
 				for (const convertedLink of convertedLinks)
 				{
-					queryResults.push(InlineQueryResultBuilder.article(convertedLink.hostname, `Convert ${ Converter.name } link with ${ convertedLink.hostname } 🔀`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true } }))
-					// queryResults.push(InlineQueryResultBuilder.article(convertedLink.hostname, `Convert ${ Converter.name } link silently with ${ convertedLink.hostname } 🔀🔕`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true }, disable_notification: true }))
+					queryResults.push(InlineQueryResultBuilder.article(convertedLink.hostname, `Convert ${ Converter.name } link with ${ convertedLink.hostname } 🔀`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true, prefer_large_media: true } }))
+					// queryResults.push(InlineQueryResultBuilder.article(convertedLink.hostname, `Convert ${ Converter.name } link silently with ${ convertedLink.hostname } 🔀🔕`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true, prefer_large_media: true }, disable_notification: true }))
 				}
 
 				await ctx.answerInlineQuery(queryResults)


### PR DESCRIPTION
'Turns out that link previews _sometimes_ don't show the same way between desktop and mobile and that's why there's a `prefer_[large|small]_media` option on the API. To nicely ask the Telegram client to follow some desired format.

So here's the obligatory "today I learned it needs this" patch.