### PR TITLE
Disable expanding links for Instagram on default suggested config

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -59,6 +59,8 @@ links:
       - https://eeinstagram.com
       - https://kkinstagram.com
       - https://ddinstagram.com
+		settings:
+			expand: false
   - name: TikTok
     origins:
       - https://tiktok.com


### PR DESCRIPTION
Fixes #49 where Instagram links would get expanded but end up on the login page due to new login restrictions from Meta.