### PR TITLE
Remove vxtiktok from example configuration

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,7 +65,6 @@ links:
     origins:
       - https://tiktok.com
     destinations:
-      - https://vxtiktok.com
       - https://tfxktok.com
       - https://tiktokez.com
   - name: Snapchat


### PR DESCRIPTION
Vxtiktok was shutdown after legal request as can be seen from previews generated by the site.