### PR TITLE
Add Deno to Dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,17 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true # https://github.com/denoland/deno/issues/26788#issuecomment-4387927088
 updates:
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
-  # - package-ecosystem: "deno"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "monthly"
+      interval: "weekly"


### PR DESCRIPTION

## Summary

Since Deno packages are now supported by Dependabot, let's get them checked automatically too with the others.
Also, I changed my mind and prefer a weekly check I think.

## AI tools usage disclosure

No AI used.