### PR TITLE
Fix inline queries response sometimes failing

### DIFF
--- a/src/actions/main.ts
+++ b/src/actions/main.ts
@@ -434,10 +434,10 @@ export class MainActions implements BotActions
 					}
 
 					logger.debug(`Got ${ convertedLinks.length } results`)
-					for (let i = 0; i < convertedLinks.length; i++)
+					for (let index = 0; index < convertedLinks.length; index++)
 					{
-						const convertedLink = convertedLinks[i]
-						const resultId = `${ i }_${ convertedLink.toString() }`
+						const convertedLink = convertedLinks[index]
+						const resultId = index.toString() // Using index as result ID as it's short (fitting in TG's 64-character limit) but still unique.
 						queryResults.push(InlineQueryResultBuilder.article(resultId, `Convert ${ Converter.name } link with ${ convertedLink.hostname } 🔀`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true, prefer_large_media: true } }))
 					}
 

--- a/src/actions/main.ts
+++ b/src/actions/main.ts
@@ -437,7 +437,7 @@ export class MainActions implements BotActions
 					for (let index = 0; index < convertedLinks.length; index++)
 					{
 						const convertedLink = convertedLinks[index]
-						const resultId = index.toString() // Using index as result ID as it's short (fitting in TG's 64-character limit) but still unique.
+						const resultId = convertedLink.hostname
 						queryResults.push(InlineQueryResultBuilder.article(resultId, `Convert ${ Converter.name } link with ${ convertedLink.hostname } 🔀`).text(convertedLink.toString(), { link_preview_options: { show_above_text: true, prefer_large_media: true } }))
 					}
 

--- a/src/main_test.ts
+++ b/src/main_test.ts
@@ -17,8 +17,8 @@ const FurAffinityConverter: SimpleLinkConverter = new SimpleLinkConverter("FurAf
 
 Deno.test("Link expanding", async (): Promise<void> =>
 {
-	const Link: URL = new URL("https://furaffinity.net/view/58904471/")
-	const Result: URL = new URL("https://www.furaffinity.net/view/58904471/")
+	const Link: URL = new URL("https://youtu.be/_r53PoMVZTQ")
+	const Result: URL = new URL("https://www.youtube.com/watch?v=_r53PoMVZTQ&feature=youtu.be")
 	assertEquals(await FurAffinityConverter.expandLink(Link), Result)
 })
 

--- a/src/main_test.ts
+++ b/src/main_test.ts
@@ -18,7 +18,7 @@ const FurAffinityConverter: SimpleLinkConverter = new SimpleLinkConverter("FurAf
 Deno.test("Link expanding", async (): Promise<void> =>
 {
 	const Link: URL = new URL("https://furaffinity.net/view/58904471/")
-	const Result: URL = new URL("https://furaffinity.net/view/58904471/")
+	const Result: URL = new URL("https://www.furaffinity.net/view/58904471/")
 	assertEquals(await FurAffinityConverter.expandLink(Link), Result)
 })
 


### PR DESCRIPTION
## Summary

Resolves #89 where the bot would not provide inline query results for some links.
'Turns out using the full URL as the response ID was the culprit as it was sometimes too long for [what Telegram allowed](https://core.telegram.org/bots/api#inlinequeryresultarticle).
Also edited the link expansion test to use a YouTube link instead for better consistency of results (FA link would expand with `www.` in some occasions but not others) and also for better showing the actual result of that action.

## AI tools usage disclosure

No AI assistance was used.